### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Folgende Funktionen beinhaltet das Smartcar Symcon Repository
 
 - __Smartcar__ ([Dokumentation](SMCAR))   
 
-Dieses Modul ermöglicht, Daten von Fahrzeugen über die Smartcar-Plattform abzufragen. Erstelle ein Profil und verbinde dein Fahrzeug oder ein Testfahrzeug (https://smartcar.com/de) Smartcar unterstützt aktuell 43 Fahrzeugmarken. Prüfe hier welche Endpunkte dein Fahrezug unterstützt. (https://smartcar.com/de/product/compatible-vehicles)
+Dieses Modul ermöglicht, Daten von Fahrzeugen über die Smartcar-Plattform abzufragen. Erstelle ein Profil und verbinde dein Fahrzeug oder ein Testfahrzeug (https://smartcar.com/de) Smartcar unterstützt aktuell 43 Fahrzeugmarken. Prüfe hier welche Endpunkte dein Fahrzeug unterstützt. (https://smartcar.com/de/product/compatible-vehicles)

--- a/SMCAR/README.md
+++ b/SMCAR/README.md
@@ -8,7 +8,7 @@ Smartcar unterstützt aktuell 43 Fahrzeugmarken. Prüfe hier welche Endpunkte de
 Das Modul verbindet sich über OAuth 2.0 mit der Smartcar API. 
 Daher ist es erforderlich, eine Redirect URI in der Smartcar-Konfiguration einzutragen. 
 Die Redirect URI ist der Pfad zum Webhook, welchen das Modul automatisch anlegt. 
-Dieser Pfad setzt sich aus deiner Connenct-Adresse und dem Pfad des Webhook zusammen. 
+Dieser Pfad setzt sich aus deiner Connect-Adresse und dem Pfad des Webhooks zusammen.
 Der Pfad der Redirect-URI wird oben im Konfigurationsformular angezeigt. 
 Diesen hinterlegst du dann in der Konfiguration von Smartcar unter 'REDIRECT URIS' Dies sieht zB so aus: https://hruw8ehwWERUOwehrWWoiuh.ipmagic.de/hook/smartcar_15583
 Wenn du im Konfigurationsformular die Scopes gewählt oder geändert hast, sind diese erneut über den Button 'Smartcar verbinden' bei Smartcar zu registrieren.
@@ -20,8 +20,8 @@ Aktuell sind folgende Scopes (Endpunkte) durch das Modul unterstützt:
 * "Standort lesen (/location)"
 * "Reifendruck lesen (/tires/pressure)"
 * "Kilometerstand lesen (/odometer)"
-* "Batteriestlevel lesen (/battery)"
-* "Batterieststatus lesen (/battery/capacity)"
+* "Batterielevel lesen (/battery)"
+* "Batteriestatus lesen (/battery/capacity)"
 * "Motoröl lesen (/oil)"
 * "Kraftstoffstand lesen (/fuel)"
 * "Sicherheitsstatus lesen (/security)"
@@ -49,19 +49,19 @@ Aktuell sind folgende Ansteuerungen unterstützt
 
 ### 1. Funktionsumfang
 
-* Abfrage der ausgewählterFahrzeugdaten und ausführen verschiedener Ansteuerung am Fahrzeug.
+* Abfrage der ausgewählten Fahrzeugdaten und Ausführen verschiedener Ansteuerungen am Fahrzeug.
 * Die kostenlose Version unterstützt ein Fahrzeug mit 500 API-Calls pro Monat.
 * Es gibt eine Bezahlversion für 2.99$ mit 1000 API-Calls pro Monat
-* Die Testfahrzeuge der Smartcar-Plattform sind unterstützt. Zum testen sollten diese Verwendet werden, um den API-Verbrauch des Live-Fahrzeuges zu schonen.
+* Die Testfahrzeuge der Smartcar-Plattform sind unterstützt. Zum testen sollten diese verwendet werden, um den API-Verbrauch des Live-Fahrzeuges zu schonen.
 * Vorsicht: Frag nur Endpunkte ab, die du wirklich brauchst, sonst ist das Guthaben schnell aufgebraucht. Lies dazu weiter unten die [PHP-Befehlsreferenz](#7-php-befehlsreferenz)
 * In der aktuellen Version dieses Moduls ist ein Fahrzeug unterstützt, für mehrere Fahrzeuge/Profile ist das Modul mehrmals anzulegen.
-* Im Smartcar-Profil können mehrere Redirct-URI's angelegt werden, womit auch mehrere Module mit Zugriff auf dasselbe Smartcar-Konto unterstützt sind.
+* Im Smartcar-Profil können mehrere Redirect-URI's angelegt werden, womit auch mehrere Module mit Zugriff auf dasselbe Smartcar-Konto unterstützt sind.
 * Nicht unterstützt ist ein Benutzerprofil bei einem Fahrzeug-Hersteller, wo mehrere Fahrzeuge verknüpft sind. Dies ist aber nur ein Thema, wenn mehrere Fahrzeuge desselben Herstellers gehalten werden. Hier muss dann jedes Fahrzeug auf ein anderes Profil lauten.
 
 ### 2. Voraussetzungen
 
 - IP-Symcon ab Version 7.0
-- Smartcar Profil mit einem Test-Fahrzeug oder einem Live-Fahrezug.
+- Smartcar Profil mit einem Test-Fahrzeug oder einem Live-Fahrzeug.
 
 ### 3. Software-Installation
 
@@ -79,10 +79,10 @@ Name     | Beschreibung
 Redirect-URI                |  Das ist der Pfad zum Webhook. Dieser Pfad gehört in die Konfiguration von Smartcar unter REDIRECT URIS.
 Client ID                   |  Entnimm diesen in der Konfiguration von Smartcar unter OAuth
 Client Secret               |  Entnimm diesen in der Konfiguration von Smartcar unter OAuth
-Verbindungsmodus            |  Hier definierst du, ob es sich um ein Simmuliertes oder ein Live-Fahrzeug handelt. Die Fahrzeuge verwaltest du im Dashboard von Smartcar. Es kann auch zwischen simmulierem und Live-Fahrezug gewechstelt werden, jedoch muss danach 'Smartcar verbinden' erneut gewählt werden.
-Berchtigungen (Scopes)      |  Hier sind die aktuell vom Modul unterstützen Scopes zur Auswahl. Wichtig ist, dass alle angewählt werden, die später abgefragt werden, sonst werden hier keine Werte geliefert. Im Zweifelsfalle vor der Abfrage alle aktivieren. Die Variablen werden automatisch erstellt und beim Deaktivieren wieder gelöscht. Die Berechtigungen bleiben aber.
-Smartcar verbinden         |  Es öffnet siche ein Browserfenster, wo du dich mit deinen Zugangsdaten vom Fahrzeughersteller anmeldest und die gewählten Berechtigungen bei Smartcar noch genemigst. Am Anschluss erscheint eine Erfolgsmeldung und die Zugriff-Token werden über die Redirect-URI an das Modul übertragen.
-Fahrzeugdaten abrufen       |  Hier rufst du alle aktivierten Scopes ab. Sei vorsichtig bei einem Live-Fahrzeug. Fünf aktivierte Scopes ergeben 5 API-Calls. Lies hier [PHP-Befehlsreferenz](#7-php-befehlsreferenz) wie du exklusiv die gewünschten Variablen aktualisierst.
+Verbindungsmodus            |  Hier definierst du, ob es sich um ein Simuliertes oder ein Live-Fahrzeug handelt. Die Fahrzeuge verwaltest du im Dashboard von Smartcar. Es kann auch zwischen simuliertem und Live-Fahrzeug gewechselt werden, jedoch muss danach 'Smartcar verbinden' erneut gewählt werden.
+Berechtigungen (Scopes)      |  Hier sind die aktuell vom Modul unterstützten Scopes zur Auswahl. Wichtig ist, dass alle angewählt werden, die später abgefragt werden, sonst werden hier keine Werte geliefert. Im Zweifelsfalle vor der Abfrage alle aktivieren. Die Variablen werden automatisch erstellt und beim Deaktivieren wieder gelöscht. Die Berechtigungen bleiben aber.
+Smartcar verbinden         |  Es öffnet sich ein Browserfenster, wo du dich mit deinen Zugangsdaten vom Fahrzeughersteller anmeldest und die gewählten Berechtigungen bei Smartcar noch genehmigst. Am Anschluss erscheint eine Erfolgsmeldung und die Zugriff-Token werden über die Redirect-URI an das Modul übertragen.
+Fahrzeugdaten abrufen       |  Hier rufst du alle aktivierten Scopes ab. Sei vorsichtig bei einem Live-Fahrzeug. Fünf aktivierte Scopes ergeben 5 API-Calls. Lies hier [PHP-Befehlsreferenz](#7-php-befehlsreferenz), wie du exklusiv die gewünschten Variablen aktualisierst.
 
 
 ### 5. Statusvariablen und Profile
@@ -109,9 +109,9 @@ Die Variablen zur Steuerung der Fahrzeugfunktion können aus der Visualisierung 
 
 ### 7. PHP-Befehlsreferenz
 
-Hier findest du die Info, wie geziehlt (zb über einen Ablaufplan) nur bestimmte Endpunkte (Scopes) abgefragt werden, um API-Calls zu sparen. 
-Ein Scenario wäre, dass der SOC nur bei aktiviertem Ladevorgang alle 15min über einen Ablaufplan aktualisiert wird.
-Beachte, dass nur im Konfigurationsformuler (Berechtigungen) freigegebene Scopes abgefragt werden können. Falls über einen Ablaufplan mehere Scopes nacheinander abgerufen werden, ist ein Abstand von ca 2 Minuten empfehlensert, da Smartcar bei häufigerer Abfragefrequnz diese blockiert.
+Hier findest du die Info, wie gezielt (z.B. über einen Ablaufplan) nur bestimmte Endpunkte (Scopes) abgefragt werden, um API-Calls zu sparen. 
+Ein Szenario wäre, dass der SOC nur bei aktiviertem Ladevorgang alle 15 Minuten über einen Ablaufplan aktualisiert wird.
+Beachte, dass nur im Konfigurationsformular (Berechtigungen) freigegebene Scopes abgefragt werden können. Falls über einen Ablaufplan mehrere Scopes nacheinander abgerufen werden, ist ein Abstand von ca 2 Minuten empfehlenswert, da Smartcar bei häufigerer Abfragefrequenz diese blockiert.
 
 Befehl   | Beschreibung
 ------ | -------
@@ -119,25 +119,25 @@ SMCAR_FetchBatteryCapacity(12345);  |   Abfrage der Batteriekapazität
 SMCAR_FetchBatteryLevel(12345);     |   Abfrage des Batterieladestand (SOC) und der Reichweite Batterie
 SMCAR_FetchChargeLimit(12345);      |   Abfrage des Ladelimits
 SMCAR_FetchChargeStatus(12345);     |   Abfrage des Ladestatus
-SMCAR_FetchEngineOil(12345);        |   Abfrage der restliche Oellebensdauer
+SMCAR_FetchEngineOil(12345);        |   Abfrage der restlichen Öllebensdauer
 SMCAR_FetchFuel(12345);             |   Abfrage des Tankvolumens und der Reichweite Tank    
 SMCAR_FetchLocation(12345);         |   Abfragen der GPS-Koordinaten
 SMCAR_FetchOdometer(12345);         |   Abfragen des Kilometerstandes
 SMCAR_FetchSecurity(12345);         |   Abfrage des Verriegelungsstatus der Türen, Klappen und Fenster
 SMCAR_FetchTires(12345);            |   Abfrage des Reifendruckes
 SMCAR_FetchVIN(12345);              |   Abfrage der Fahrgestellnummer
-SMCAR_FetchVehicleData(12345);      |   Alle im Modul aktiverten Scopes abfragen. Vorsicht, es könnten sehr viele API-Calls verbraucht werden
+SMCAR_FetchVehicleData(12345);      |   Alle im Modul aktivierten Scopes abfragen. Vorsicht, es könnten sehr viele API-Calls verbraucht werden
 
 ### 8. Versionen
 
 Version 2.0 (02.01.2025)
-- Code und Readme anepasst
+- Code und Readme angepasst
 - Version um die Store-Kompatibilität zu erlangen
 
 Version 1.3 (26.12.2024)
 - Timer für Token-Erneuerung auf 90 min fixiert.
 - Token wird nun zusätzlich bei jeder Konfigurationsänderung erneuert.
-- Abhandlung bei 401-Fehler (Authentication) wärend der Datenabfrage hinzugefügt, so dass der Access-Token erneuert und die Abfrage erneut ausgeführt wird.
+- Abhandlung bei 401-Fehler (Authentication) während der Datenabfrage hinzugefügt, so dass der Access-Token erneuert und die Abfrage erneut ausgeführt wird.
 - Fehlerausgabe in Log aktiviert
 
 Version 1.2 (22.12.2024)


### PR DESCRIPTION
## Summary
- fix typo in root README
- fix battery level lines and many other typos in module README

## Testing
- `php -l SMCAR/module.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ecbf6c08883268f096c8b5364aed0