### PR TITLE
Fix charge status endpoint

### DIFF
--- a/SMCAR/form.json
+++ b/SMCAR/form.json
@@ -91,7 +91,7 @@
         {
           "type": "CheckBox",
           "name": "ScopeReadChargeStatus",
-          "caption": "Ladestatus lesen (/charge/status)"
+          "caption": "Ladestatus lesen (/charge)"
         },
         {
           "type": "CheckBox",

--- a/SMCAR/module.php
+++ b/SMCAR/module.php
@@ -976,8 +976,8 @@ class Smartcar extends IPSModule
     
     public function FetchChargeStatus()
     {
-        $this->FetchSingleEndpoint('/charge/status'); // Ladestatus
-    }    
+        $this->FetchSingleEndpoint('/charge'); // Ladestatus
+    }
 
     private function FetchSingleEndpoint(string $path)
     {


### PR DESCRIPTION
## Summary
- query `/charge` endpoint in `FetchChargeStatus`
- adjust form caption for charge status checkbox

## Testing
- `pytest -q`
- `php -l SMCAR/module.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ecd9fc86c8326a56e4662a18555a0